### PR TITLE
Avoid corrupting documents when tracking destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 * Your contribution here.
 * [#236](https://github.com/mongoid/mongoid-history/pull/236): Fix Ruby 2.7 keyword argument warnings - [@vasilysn](https://github.com/vasilysn).
 * [#237](https://github.com/mongoid/mongoid-history/pull/237): Fix tracking subclasses with additional fields - [@getaroom](https://github.com/getaroom).
-* [](): Don't track changes on embedded documents if an ancestor is being destroyed in the same operation - [@getaroom](https://github.com/getaroom).
+* [#239](https://github.com/mongoid/mongoid-history/pull/239): Optimize `modified_attributes_for_create` 6-7x - [@getaroom](https://github.com/getaroom).
+* [](): Don't update version on embedded documents if an ancestor is being destroyed in the same operation - [@getaroom](https://github.com/getaroom).
 
 ### 0.8.2 (2019/12/02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Your contribution here.
 * [#236](https://github.com/mongoid/mongoid-history/pull/236): Fix Ruby 2.7 keyword argument warnings - [@vasilysn](https://github.com/vasilysn).
 * [#237](https://github.com/mongoid/mongoid-history/pull/237): Fix tracking subclasses with additional fields - [@getaroom](https://github.com/getaroom).
+* [](): Don't track changes on embedded documents if an ancestor is being destroyed in the same operation - [@getaroom](https://github.com/getaroom).
 
 ### 0.8.2 (2019/12/02)
 

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -308,12 +308,12 @@ module Mongoid
         protected
 
         def track_history_for_action?(action)
-          track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?) && !ancestor_flagged_for_destroy?(_parent)
+          track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?)
         end
 
         def track_history_for_action(action)
           if track_history_for_action?(action)
-            current_version = increment_current_version
+            current_version = ancestor_flagged_for_destroy?(_parent) ? send(history_trackable_options[:version_field]) : increment_current_version
             last_track = self.class.tracker_class.create!(
               history_tracker_attributes(action.to_sym)
               .merge(version: current_version, action: action.to_s, trackable: self)

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -299,10 +299,12 @@ module Mongoid
           expanded_key
         end
 
+        def next_version
+          (send(history_trackable_options[:version_field]) || 0) + 1
+        end
+
         def increment_current_version
-          current_version = (send(history_trackable_options[:version_field]) || 0) + 1
-          send("#{history_trackable_options[:version_field]}=", current_version)
-          current_version
+          next_version.tap { |version| send("#{history_trackable_options[:version_field]}=", version) }
         end
 
         protected
@@ -313,7 +315,7 @@ module Mongoid
 
         def track_history_for_action(action)
           if track_history_for_action?(action)
-            current_version = ancestor_flagged_for_destroy?(_parent) ? send(history_trackable_options[:version_field]) : increment_current_version
+            current_version = ancestor_flagged_for_destroy?(_parent) ? next_version : increment_current_version
             last_track = self.class.tracker_class.create!(
               history_tracker_attributes(action.to_sym)
               .merge(version: current_version, action: action.to_s, trackable: self)

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -128,7 +128,7 @@ module Mongoid
         private
 
         def ancestor_flagged_for_destroy?(doc)
-          doc && doc.flagged_for_destroy? || ancestor_flagged_for_destroy?(doc._parent)
+          doc && (doc.flagged_for_destroy? || ancestor_flagged_for_destroy?(doc._parent))
         end
 
         def get_versions_criteria(options_or_version)
@@ -175,9 +175,7 @@ module Mongoid
         end
 
         def traverse_association_chain(node = self)
-          list = node._parent ? traverse_association_chain(node._parent) : []
-          list << association_hash(node)
-          list
+          (node._parent ? traverse_association_chain(node._parent) : []).tap { |list| list << association_hash(node) }
         end
 
         def association_hash(node = self)
@@ -261,10 +259,7 @@ module Mongoid
         end
 
         def clear_trackable_memoization
-          @history_tracker_attributes = nil
-          @modified_attributes_for_create = nil
-          @modified_attributes_for_update = nil
-          @history_tracks = nil
+          @history_tracker_attributes = @modified_attributes_for_create = @modified_attributes_for_update = @history_tracks = nil
         end
 
         # Transform hash of pair of changes into an `original` and `modified` hash

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -127,6 +127,10 @@ module Mongoid
 
         private
 
+        def ancestor_flagged_for_destroy?(doc)
+          doc && doc.flagged_for_destroy? || ancestor_flagged_for_destroy?(doc._parent)
+        end
+
         def get_versions_criteria(options_or_version)
           if options_or_version.is_a? Hash
             options = options_or_version
@@ -309,7 +313,7 @@ module Mongoid
         protected
 
         def track_history_for_action?(action)
-          track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?)
+          track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?) && !ancestor_flagged_for_destroy?(_parent)
         end
 
         def track_history_for_action(action)

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -15,6 +15,26 @@ describe Mongoid::History::Trackable do
       include Mongoid::Attributes::Dynamic unless Mongoid::Compatibility::Version.mongoid3?
     end
 
+    class MyDeeplyNestedModel
+      include Mongoid::Document
+      include Mongoid::History::Trackable
+
+      embeds_many :children, class_name: 'MyNestableModel', cascade_callbacks: true # The problem only occurs if callbacks are cascaded
+      accepts_nested_attributes_for :children, allow_destroy: true
+      track_history modifier_field: nil
+    end
+
+    class MyNestableModel
+      include Mongoid::Document
+      include Mongoid::History::Trackable
+
+      embedded_in :parent, class_name: 'MyDeeplyNestedModel'
+      embeds_many :children, class_name: 'MyNestableModel', cascade_callbacks: true
+      accepts_nested_attributes_for :children, allow_destroy: true
+      field :name, type: String
+      track_history modifier_field: nil
+    end
+
     class HistoryTracker
       include Mongoid::History::Tracker
     end
@@ -29,6 +49,8 @@ describe Mongoid::History::Trackable do
     Object.send(:remove_const, :MyDynamicModel)
     Object.send(:remove_const, :HistoryTracker)
     Object.send(:remove_const, :User)
+    Object.send(:remove_const, :MyDeeplyNestedModel)
+    Object.send(:remove_const, :MyNestableModel)
   end
 
   let(:user) { User.create! }
@@ -739,6 +761,71 @@ describe Mongoid::History::Trackable do
       expect do
         expect { m.destroy }.to raise_error(StandardError)
       end.to change(Tracker, :count).by(0)
+    end
+
+    context 'with a deeply nested model' do
+      let(:m) do
+        MyDeeplyNestedModel.create!(
+          children: [
+            MyNestableModel.new(
+              name: 'grandparent',
+              children: [
+                MyNestableModel.new(
+                  name: 'parent 1',
+                  children: [
+                    MyNestableModel.new(name: 'child 1')
+                  ]
+                ),
+                MyNestableModel.new(
+                  name: 'parent 2',
+                  children: [
+                    MyNestableModel.new(name: 'child 2')
+                  ]
+                )
+              ]
+            )
+          ]
+        )
+      end
+
+      it 'does not corrupt embedded models' do
+        m.update_attributes(
+          'children_attributes' => [
+            {
+              'id' =>  m.children[0].id,
+              'name' => 'grandparent',
+              'children_attributes' => [
+                {
+                  'id' => m.children[0].children[0].id,
+                  '_destroy' => '0',
+                  'name' => 'parent 1',
+                  'children_attributes' => [
+                    {
+                      'id' => m.children[0].children[0].children[0].id,
+                      'name' => 'child 1'
+                    }
+                  ]
+                },
+                {
+                  'id' => m.children[0].children[1].id,
+                  '_destroy' => '1',
+                  'name' => 'parent 2',
+                  'children_attributes' => [
+                    {
+                      'id' => m.children[0].children[1].children[0].id,
+                      'name' => 'child 2'
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        )
+
+        # When the problem occurs, the 2nd child will continue to be
+        # present, but will only contain the version attribute
+        expect(m.reload.children[0].children.count).to eq 1
+      end
     end
   end
 

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -787,9 +787,8 @@ describe Mongoid::History::Trackable do
           ]
         )
       end
-
-      it 'does not corrupt embedded models' do
-        m.update_attributes(
+      let(:attributes) do
+        {
           'children_attributes' => [
             {
               'id' =>  m.children[0].id,
@@ -820,11 +819,32 @@ describe Mongoid::History::Trackable do
               ]
             }
           ]
-        )
+        }
+      end
 
+      subject(:updated) do
+        m.update_attributes attributes
+        m.reload
+      end
+
+      let(:names_of_destroyed) do
+        destroy_track_names = MyDeeplyNestedModel.tracker_class
+          .where('association_chain.id' => updated.id, 'action' => 'destroy')
+          .map { |track| track.original['name'] }
+      end
+
+      it 'does not corrupt embedded models' do
         # When the problem occurs, the 2nd child will continue to be
         # present, but will only contain the version attribute
-        expect(m.reload.children[0].children.count).to eq 1
+        expect(updated.children[0].children.count).to eq 1
+      end
+
+      it 'creates a history track for the doc explicitly destroyed' do
+        expect(names_of_destroyed).to include 'parent 2'
+      end
+
+      it 'creates a history track for the doc implicitly destroyed' do
+        expect(names_of_destroyed).to include 'child 2'
       end
     end
   end


### PR DESCRIPTION
If an embedded document has its version incremented, but an ancester
is flagged for destroy and the root document is not, then this causes
conflicts, which are written to the otherwise empty embedded document,
leaving a corrupt document in storage.

Note that this only happens with the parent document cascades
callbacks.