### PR TITLE
Delete embedded causes corruption

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -56,7 +56,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 191
+  Max: 200
 
 # Offense count: 6
 Metrics/PerceivedComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -31,7 +31,7 @@ Metrics/AbcSize:
 # Offense count: 122
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 837
+  Max: 900
 
 # Offense count: 1
 # Configuration parameters: CountComments.

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -19,8 +19,6 @@ module Mongoid
           end
 
           include MyInstanceMethods
-          include MyPrivateInstanceMethods
-          include MyProtectedInstanceMethods
           extend SingletonMethods
 
           delegate :history_trackable_options, to: 'self.class'
@@ -138,9 +136,7 @@ module Mongoid
         def _create_relation(name, value)
           send("create_#{self.class.relation_alias(name)}!", value)
         end
-      end
 
-      module MyPrivateInstanceMethods
         private
 
         def ancestor_flagged_for_destroy?(doc)
@@ -322,9 +318,7 @@ module Mongoid
         def increment_current_version
           next_version.tap { |version| send("#{history_trackable_options[:version_field]}=", version) }
         end
-      end
 
-      module MyProtectedInstanceMethods
         protected
 
         def track_history_for_action?(action)

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -331,9 +331,16 @@ module Mongoid
           track_history? && !(action.to_sym == :update && modified_attributes_for_update.blank?)
         end
 
+        def increment_current_version?(action)
+          !(
+            (action == :destroy) ||
+            ancestor_flagged_for_destroy?(_parent)
+          )
+        end
+
         def track_history_for_action(action)
           if track_history_for_action?(action)
-            current_version = ancestor_flagged_for_destroy?(_parent) ? next_version : increment_current_version
+            current_version = increment_current_version?(action) ? increment_current_version : next_version
             last_track = self.class.tracker_class.create!(
               history_tracker_attributes(action.to_sym)
               .merge(version: current_version, action: action.to_s, trackable: self)

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -19,6 +19,8 @@ module Mongoid
           end
 
           include MyInstanceMethods
+          include MyPrivateInstanceMethods
+          include MyProtectedInstanceMethods
           extend SingletonMethods
 
           delegate :history_trackable_options, to: 'self.class'
@@ -136,7 +138,9 @@ module Mongoid
         def _create_relation(name, value)
           send("create_#{self.class.relation_alias(name)}!", value)
         end
+      end
 
+      module MyPrivateInstanceMethods
         private
 
         def ancestor_flagged_for_destroy?(doc)
@@ -318,7 +322,9 @@ module Mongoid
         def increment_current_version
           next_version.tap { |version| send("#{history_trackable_options[:version_field]}=", version) }
         end
+      end
 
+      module MyProtectedInstanceMethods
         protected
 
         def track_history_for_action?(action)

--- a/lib/mongoid/history/trackable.rb
+++ b/lib/mongoid/history/trackable.rb
@@ -332,10 +332,7 @@ module Mongoid
         end
 
         def increment_current_version?(action)
-          !(
-            (action == :destroy) ||
-            ancestor_flagged_for_destroy?(_parent)
-          )
+          action != :destroy && !ancestor_flagged_for_destroy?(_parent)
         end
 
         def track_history_for_action(action)

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -509,8 +509,8 @@ describe Mongoid::History do
 
       it 'should be possible to destroy after re-create embedded from parent' do
         comment.destroy
-        post.history_tracks.last.undo!(user)
-        post.history_tracks.last.undo!(user)
+        post.history_tracks[-1].undo!(user)
+        post.history_tracks[-1].undo!(user)
         post.reload
         expect(post.comments.count).to eq(0)
       end

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -1,64 +1,6 @@
 require 'spec_helper'
 
-describe Mongoid::History::Trackable do
-  before :each do
-    class MyModel
-      include Mongoid::Document
-      include Mongoid::History::Trackable
-
-      field :foo
-    end
-
-    class MyDynamicModel
-      include Mongoid::Document
-      include Mongoid::History::Trackable
-      include Mongoid::Attributes::Dynamic unless Mongoid::Compatibility::Version.mongoid3?
-    end
-
-    class MyDeeplyNestedModel
-      include Mongoid::Document
-      include Mongoid::History::Trackable
-
-      embeds_many :children, class_name: 'MyNestableModel', cascade_callbacks: true # The problem only occurs if callbacks are cascaded
-      accepts_nested_attributes_for :children, allow_destroy: true
-      track_history modifier_field: nil
-    end
-
-    class MyNestableModel
-      include Mongoid::Document
-      include Mongoid::History::Trackable
-
-      embedded_in :parent, class_name: 'MyDeeplyNestedModel'
-      embeds_many :children, class_name: 'MyNestableModel', cascade_callbacks: true
-      accepts_nested_attributes_for :children, allow_destroy: true
-      field :name, type: String
-      track_history modifier_field: nil
-    end
-
-    class HistoryTracker
-      include Mongoid::History::Tracker
-    end
-
-    class User
-      include Mongoid::Document
-    end
-  end
-
-  after :each do
-    Object.send(:remove_const, :MyModel)
-    Object.send(:remove_const, :MyDynamicModel)
-    Object.send(:remove_const, :HistoryTracker)
-    Object.send(:remove_const, :User)
-    Object.send(:remove_const, :MyDeeplyNestedModel)
-    Object.send(:remove_const, :MyNestableModel)
-  end
-
-  let(:user) { User.create! }
-
-  it 'should have #track_history' do
-    expect(MyModel).to respond_to :track_history
-  end
-
+shared_examples 'track history' do
   describe '#track_history' do
     before :each do
       class MyModelWithNoModifier
@@ -590,6 +532,193 @@ describe Mongoid::History::Trackable do
       end
     end
   end
+end
+
+shared_examples 'track update' do
+  describe '#track_update' do
+    before(:each) { MyModel.track_history(on: :foo, track_update: true) }
+
+    let!(:m) { MyModel.create!(foo: 'bar', modifier: user) }
+
+    it 'should create history' do
+      expect { m.update_attributes!(foo: 'bar2') }.to change(Tracker, :count).by(1)
+    end
+
+    it 'should not create history when error raised' do
+      expect(m).to receive(:update_attributes!).and_raise(StandardError)
+      expect do
+        expect { m.update_attributes!(foo: 'bar2') }.to raise_error(StandardError)
+      end.to change(Tracker, :count).by(0)
+    end
+  end
+end
+
+shared_examples 'track destroy' do
+  describe '#track_destroy' do
+    before(:each) { MyModel.track_history(on: :foo, track_destroy: true) }
+
+    let!(:m) { MyModel.create!(foo: 'bar', modifier: user) }
+
+    it 'should create history' do
+      expect { m.destroy }.to change(Tracker, :count).by(1)
+    end
+
+    it 'should not create history when error raised' do
+      expect(m).to receive(:destroy).and_raise(StandardError)
+      expect do
+        expect { m.destroy }.to raise_error(StandardError)
+      end.to change(Tracker, :count).by(0)
+    end
+
+    context 'with a deeply nested model' do
+      let(:m) do
+        MyDeeplyNestedModel.create!(
+          children: [
+            MyNestableModel.new(
+              name: 'grandparent',
+              children: [
+                MyNestableModel.new(name: 'parent 1', children: [MyNestableModel.new(name: 'child 1')]),
+                MyNestableModel.new(name: 'parent 2', children: [MyNestableModel.new(name: 'child 2')])
+              ]
+            )
+          ]
+        )
+      end
+      let(:attributes) do
+        {
+          'children_attributes' => [
+            {
+              'id' =>  m.children[0].id,
+              'children_attributes' => [
+                { 'id' => m.children[0].children[0].id, '_destroy' => '0' },
+                { 'id' => m.children[0].children[1].id, '_destroy' => '1' }
+              ]
+            }
+          ]
+        }
+      end
+
+      subject(:updated) do
+        m.update_attributes attributes
+        m.reload
+      end
+
+      let(:names_of_destroyed) do
+        MyDeeplyNestedModel.tracker_class
+                           .where('association_chain.id' => updated.id, 'action' => 'destroy')
+                           .map { |track| track.original['name'] }
+      end
+
+      it 'does not corrupt embedded models' do
+        expect(updated.children[0].children.count).to eq 1 # When the problem occurs, the 2nd child will continue to be present, but will only contain the version attribute
+      end
+
+      it 'creates a history track for the doc explicitly destroyed' do
+        expect(names_of_destroyed).to include 'parent 2'
+      end
+
+      it 'creates a history track for the doc implicitly destroyed' do
+        expect(names_of_destroyed).to include 'child 2'
+      end
+    end
+  end
+end
+
+shared_examples 'track create' do
+  describe '#track_create' do
+    before :each do
+      class MyModelWithNoModifier
+        include Mongoid::Document
+        include Mongoid::History::Trackable
+
+        field :foo
+      end
+    end
+
+    after(:each) { Object.send(:remove_const, :MyModelWithNoModifier) }
+
+    before :each do
+      MyModel.track_history(on: :foo, track_create: true)
+      MyModelWithNoModifier.track_history modifier_field: nil
+    end
+
+    it 'should create history' do
+      expect { MyModel.create!(foo: 'bar', modifier: user) }.to change(Tracker, :count).by(1)
+    end
+
+    context 'no modifier_field' do
+      it 'should create history' do
+        expect { MyModelWithNoModifier.create!(foo: 'bar').to change(Tracker, :count).by(1) }
+      end
+    end
+
+    it 'should not create history when error raised' do
+      expect(MyModel).to receive(:create!).and_raise(StandardError)
+      expect do
+        expect { MyModel.create!(foo: 'bar') }.to raise_error(StandardError)
+      end.to change(Tracker, :count).by(0)
+    end
+  end
+end
+
+describe Mongoid::History::Trackable do
+  before :each do
+    class MyModel
+      include Mongoid::Document
+      include Mongoid::History::Trackable
+
+      field :foo
+    end
+
+    class MyDynamicModel
+      include Mongoid::Document
+      include Mongoid::History::Trackable
+      include Mongoid::Attributes::Dynamic unless Mongoid::Compatibility::Version.mongoid3?
+    end
+
+    class MyDeeplyNestedModel
+      include Mongoid::Document
+      include Mongoid::History::Trackable
+
+      embeds_many :children, class_name: 'MyNestableModel', cascade_callbacks: true # The problem only occurs if callbacks are cascaded
+      accepts_nested_attributes_for :children, allow_destroy: true
+      track_history modifier_field: nil
+    end
+
+    class MyNestableModel
+      include Mongoid::Document
+      include Mongoid::History::Trackable
+
+      embedded_in :parent, class_name: 'MyDeeplyNestedModel'
+      embeds_many :children, class_name: 'MyNestableModel', cascade_callbacks: true
+      accepts_nested_attributes_for :children, allow_destroy: true
+      field :name, type: String
+      track_history modifier_field: nil
+    end
+
+    class HistoryTracker
+      include Mongoid::History::Tracker
+    end
+
+    class User
+      include Mongoid::Document
+    end
+  end
+
+  after :each do
+    Object.send(:remove_const, :MyModel)
+    Object.send(:remove_const, :MyDynamicModel)
+    Object.send(:remove_const, :HistoryTracker)
+    Object.send(:remove_const, :User)
+    Object.send(:remove_const, :MyDeeplyNestedModel)
+    Object.send(:remove_const, :MyNestableModel)
+  end
+
+  let(:user) { User.create! }
+
+  it 'should have #track_history' do
+    expect(MyModel).to respond_to :track_history
+  end
 
   describe '#history_settings' do
     before(:each) { Mongoid::History.trackable_settings = nil }
@@ -818,126 +947,10 @@ describe Mongoid::History::Trackable do
     end
   end
 
-  describe '#track_update' do
-    before(:each) { MyModel.track_history(on: :foo, track_update: true) }
-
-    let!(:m) { MyModel.create!(foo: 'bar', modifier: user) }
-
-    it 'should create history' do
-      expect { m.update_attributes!(foo: 'bar2') }.to change(Tracker, :count).by(1)
-    end
-
-    it 'should not create history when error raised' do
-      expect(m).to receive(:update_attributes!).and_raise(StandardError)
-      expect do
-        expect { m.update_attributes!(foo: 'bar2') }.to raise_error(StandardError)
-      end.to change(Tracker, :count).by(0)
-    end
-  end
-
-  describe '#track_destroy' do
-    before(:each) { MyModel.track_history(on: :foo, track_destroy: true) }
-
-    let!(:m) { MyModel.create!(foo: 'bar', modifier: user) }
-
-    it 'should create history' do
-      expect { m.destroy }.to change(Tracker, :count).by(1)
-    end
-
-    it 'should not create history when error raised' do
-      expect(m).to receive(:destroy).and_raise(StandardError)
-      expect do
-        expect { m.destroy }.to raise_error(StandardError)
-      end.to change(Tracker, :count).by(0)
-    end
-
-    context 'with a deeply nested model' do
-      let(:m) do
-        MyDeeplyNestedModel.create!(
-          children: [
-            MyNestableModel.new(
-              name: 'grandparent',
-              children: [
-                MyNestableModel.new(name: 'parent 1', children: [MyNestableModel.new(name: 'child 1')]),
-                MyNestableModel.new(name: 'parent 2', children: [MyNestableModel.new(name: 'child 2')])
-              ]
-            )
-          ]
-        )
-      end
-      let(:attributes) do
-        {
-          'children_attributes' => [
-            {
-              'id' =>  m.children[0].id,
-              'children_attributes' => [
-                { 'id' => m.children[0].children[0].id, '_destroy' => '0' },
-                { 'id' => m.children[0].children[1].id, '_destroy' => '1' }
-              ]
-            }
-          ]
-        }
-      end
-
-      subject(:updated) do
-        m.update_attributes attributes
-        m.reload
-      end
-
-      let(:names_of_destroyed) do
-        MyDeeplyNestedModel.tracker_class
-                           .where('association_chain.id' => updated.id, 'action' => 'destroy')
-                           .map { |track| track.original['name'] }
-      end
-
-      it 'does not corrupt embedded models' do
-        expect(updated.children[0].children.count).to eq 1 # When the problem occurs, the 2nd child will continue to be present, but will only contain the version attribute
-      end
-
-      it 'creates a history track for the doc explicitly destroyed' do
-        expect(names_of_destroyed).to include 'parent 2'
-      end
-
-      it 'creates a history track for the doc implicitly destroyed' do
-        expect(names_of_destroyed).to include 'child 2'
-      end
-    end
-  end
-
-  describe '#track_create' do
-    before :each do
-      class MyModelWithNoModifier
-        include Mongoid::Document
-        include Mongoid::History::Trackable
-
-        field :foo
-      end
-    end
-
-    after(:each) { Object.send(:remove_const, :MyModelWithNoModifier) }
-
-    before :each do
-      MyModel.track_history(on: :foo, track_create: true)
-      MyModelWithNoModifier.track_history modifier_field: nil
-    end
-
-    it 'should create history' do
-      expect { MyModel.create!(foo: 'bar', modifier: user) }.to change(Tracker, :count).by(1)
-    end
-
-    context 'no modifier_field' do
-      it 'should create history' do
-        expect { MyModelWithNoModifier.create!(foo: 'bar').to change(Tracker, :count).by(1) }
-      end
-    end
-
-    it 'should not create history when error raised' do
-      expect(MyModel).to receive(:create!).and_raise(StandardError)
-      expect do
-        expect { MyModel.create!(foo: 'bar') }.to raise_error(StandardError)
-      end.to change(Tracker, :count).by(0)
-    end
-  end
+  include_examples 'track history'
+  include_examples 'track update'
+  include_examples 'track destroy'
+  include_examples 'track create'
 
   context 'changing collection' do
     before :each do

--- a/spec/unit/trackable_spec.rb
+++ b/spec/unit/trackable_spec.rb
@@ -621,6 +621,47 @@ shared_examples 'track destroy' do
         expect(names_of_destroyed).to include 'child 2'
       end
     end
+
+    context 'with multiple embeds_many models' do
+      let(:m) do
+        MyDeeplyNestedModel.create!(
+          children: [
+            MyNestableModel.new(
+              name: 'parent',
+              children: [
+                MyNestableModel.new(name: 'child 1'),
+                MyNestableModel.new(name: 'child 2'),
+                MyNestableModel.new(name: 'child 3')
+              ]
+            )
+          ]
+        )
+      end
+
+      let(:attributes) do
+        {
+          'children_attributes' => [
+            {
+              'id' =>  m.children[0].id,
+              'children_attributes' => [
+                { 'id' => m.children[0].children[0].id, '_destroy' => '0' },
+                { 'id' => m.children[0].children[1].id, '_destroy' => '1' },
+                { 'id' => m.children[0].children[2].id, '_destroy' => '1' }
+              ]
+            }
+          ]
+        }
+      end
+
+      subject(:updated) do
+        m.update_attributes attributes
+        m.reload
+      end
+
+      it 'does not corrupt the document' do
+        expect(updated.children[0].children.length).to eq(1)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This is a follow up to [this PR](https://github.com/mongoid/mongoid-history/pull/248), as we've found more instances where setting the version is causing corrupted documents.

Additionally, in order to get around some line limits that are enforced on the repo, some code has been rearranged. A commit was created for each step in the process with an explanation of the motivation.